### PR TITLE
[Theme/Gutenberg] User inner blocks hooks instead of InnerBlocks component

### DIFF
--- a/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/admin/partials/example-block-editor.js
+++ b/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/admin/partials/example-block-editor.js
@@ -1,5 +1,11 @@
 import clsx from 'clsx';
 import styles from '../example-block.module.scss?module';
+import {useInnerBlocksProps, useBlockProps} from '@wordpress/block-editor';
+
+// Inner blocks template
+const TEMPLATE = [
+  ['core/paragraph', {placeholder: 'This ExampleBlock paragraph...'}]
+];
 
 /**
  * Example gutenberg block editor partial
@@ -8,12 +14,20 @@ import styles from '../example-block.module.scss?module';
  * @param props
  */
 export const ExampleBlockEditor = (props) => {
-	const {attributes} = props;
-	const {className} = attributes;
+  const {attributes} = props;
+  const {className} = attributes;
 
-	return (
-		<div className={clsx(styles.exampleBlock, className)}>
-			<code>This is new component ExampleBlock</code>
-		</div>
-	);
+  // Create inner block element with locked template
+  const blockProps = useBlockProps();
+  const innerBlockProps = useInnerBlocksProps(blockProps, {
+    template: TEMPLATE,
+    templateLock: 'all'
+  });
+
+  return (
+    <div className={clsx(styles.exampleBlock, className)}>
+      <code>This is new component ExampleBlock</code>
+      <div {...innerBlockProps} />
+    </div>
+  );
 };

--- a/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/manifest.json
+++ b/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/manifest.json
@@ -2,7 +2,7 @@
   "blockName": "example-block",
   "category": "ew-starter",
   "title": "Example block",
-  "hasInnerBlocks": false,
+  "hasInnerBlocks": true,
   "keywords": [],
   "styles": [],
   "description": "Example block for base development",

--- a/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/public/example-block.twig
+++ b/wp-content/themes/ew-theme/assets/gutenberg/blocks/example-block/public/example-block.twig
@@ -3,5 +3,6 @@
 
 {# Example gutenberg block #}
 <div class="gb-example-block {{ attributes.className }}">
-    <code>This is new component ExampleBlock</code>
+	<code>This is new component ExampleBlock</code>
+	{{ innerContent|raw }}
 </div>

--- a/wp-content/themes/ew-theme/assets/gutenberg/helpers/BlockRegistrationHelper.js
+++ b/wp-content/themes/ew-theme/assets/gutenberg/helpers/BlockRegistrationHelper.js
@@ -1,34 +1,34 @@
 import projectManifest from '../manifest.json';
-import {InnerBlocks} from '@wordpress/editor';
 import {createElement} from '@wordpress/element';
+import {useInnerBlocksProps, useBlockProps} from '@wordpress/block-editor';
 
 /**
  * Helper for gutenberg block registration
  */
 class BlockRegistrationHelper {
-	/**
+  /**
    * Creates block name based on its name in block manifest
    * and project namespace in global manifest
    *
-	 * @param manifest Block manifest
-	 * @returns {string}
-	 */
+   * @param manifest Block manifest
+   * @returns {string}
+   */
   static getBlockName(manifest) {
-    const { projectNamespace } = projectManifest;
-    const { blockName } = manifest;
+    const {projectNamespace} = projectManifest;
+    const {blockName} = manifest;
     if (!blockName) throw new Error('Required field "blockName" is missing from the manifest.');
 
     return [projectNamespace, blockName].join('/');
   }
 
-	/**
+  /**
    * Creates block options used in block registration
    *
-	 * @param editComponent Block 'edit' function
-	 * @param manifest Block manifest
-	 * @param customOptions Additional options object
-	 * @returns {{blockName: *, title: *, description: *, category: *, keywords: *, supports: *, parent: *, styles: *, example: *, icon: (* | string), save: *, edit: *}}
-	 */
+   * @param editComponent Block 'edit' function
+   * @param manifest Block manifest
+   * @param customOptions Additional options object
+   * @returns {{blockName: *, title: *, description: *, category: *, keywords: *, supports: *, parent: *, styles: *, example: *, icon: (* | string), save: *, edit: *}}
+   */
   static getBlockOptions(editComponent, manifest, customOptions = {}) {
     const {
       blockName,
@@ -39,9 +39,10 @@ class BlockRegistrationHelper {
       supports,
       parent,
       hasInnerBlocks,
+      innerBlocksElement = 'div',
       styles,
       icon,
-			example
+      example
     } = manifest;
 
     return {
@@ -53,9 +54,16 @@ class BlockRegistrationHelper {
       supports,
       parent,
       styles,
-			example,
+      example,
       icon: icon || 'block-default',
-      save: (hasInnerBlocks ? () => createElement(InnerBlocks.Content) : () => null),
+      save: (hasInnerBlocks
+        ? () => {
+          const blockProps = useBlockProps.save();
+          const innerBlocksProps = useInnerBlocksProps.save(blockProps);
+
+          return createElement(innerBlocksElement, innerBlocksProps);
+        }
+        : () => null),
       ...customOptions,
       edit: editComponent,
     };


### PR DESCRIPTION
Before we used inner blocks using `InnerBlocks` component included from `@wordpress/block-editor`. This makes styling of inner blocks difficult in editor since the component adds multiple containers before "real" inner blocks are rendered.

By using inner block hooks (`useBlockProps` and `userInnerBlockProps`) we get more control over rendering in admin area (we can add our classes to the inner blocks container element).

We're adding new property to the manifest - `innerBlocksElement` that determines what HTML element will be used as inner blocks container, default value (that's used when the manifest property is not set) is "div".

ExampleBlock is updated to show how we use inner blocks hooks.
